### PR TITLE
Enable reload of integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ I've pulled inspiration from all of them.
 
 | | | |
 |---|---|---|
-|[hassio-plejd](https://github.com/icanos/hassio-plejd) | [@icanos](https://github.com/icanos) | Works only with Home Assistant OS.<br> Requires exclusive access to the Bluetooth dongle.<br> Does not support Bluetooth Proxy. |
+|[hassio-plejd](https://github.com/icanos/hassio-plejd) | [@icanos](https://github.com/icanos) | Works only with Home Assistant OS.<br> Relies on MQTT for communication.<br> Requires exclusive access to the Bluetooth dongle.<br> Does not support Bluetooth Proxy. |
 |[plejd2mqtt](https://github.com/thomasloven/plejd2mqtt) | [@thomasloven](https://github.com/thomasloven) | Somewhat outdated stand-alone version of the above.<br> Relies on MQTT for communication.<br> Requires exclusive access to the Bluetooth dongle.<br> Does not support Bluetooth Proxy.<br> Does not support switches or scenes. |
 |[ha-plejd](https://github.com/klali/ha-plejd) | [@klali](https://github.com/klali) <br> (also check [this fork](https://github.com/bnordli/ha-plejd/tree/to-integration) by [@bnordli](https://github.com/bnordli))| Does not communicate with the Plejd API and therefore requires you to extract the cryptokey and device data from the Plejd app somehow.<br> No auto discovery.<br> Requires exclusive access to the Bluetooth dongle.<br> Does not support Bluetooth Proxy.  |
 | [homey-plejd](https://github.com/emilohman/homey-plejd) | [@emilohman](https://github.com/emilohman) | For Homey |

--- a/custom_components/plejd/__init__.py
+++ b/custom_components/plejd/__init__.py
@@ -2,9 +2,11 @@ import logging
 
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth.match import BluetoothCallbackMatcher
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant import config_entries
 from homeassistant.helpers.event import async_track_point_in_utc_time
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 import homeassistant.util.dt as dt_util
 from homeassistant.helpers import device_registry as dr
 
@@ -14,6 +16,7 @@ from . import pyplejd
 
 _LOGGER = logging.getLogger(__name__)
 
+PLATFORMS = [Platform.LIGHT, Platform.SWITCH, Platform.BUTTON]
 
 async def async_setup(hass, config):
     if not hass.config_entries.async_entries("plejd"):
@@ -86,11 +89,9 @@ async def async_setup_entry(hass, config_entry):
     for service_info in bluetooth.async_discovered_service_info(hass, True):
         if pyplejd.PLEJD_SERVICE.lower() in service_info.advertisement.service_uuids:
             plejdManager.add_mesh_device(service_info.device)
-    
 
-    await hass.config_entries.async_forward_entry_setups(config_entry,
-            ["light", "switch", "button"]
-        )
+
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     # Ping mesh intermittently to keep the connection alive
     async def _ping(now=None):
@@ -110,8 +111,22 @@ async def async_setup_entry(hass, config_entry):
         if "ping_timer" in hass.data[DOMAIN]:
             hass.data[DOMAIN]["ping_timer"]()
         await plejdManager.disconnect()
+
     config_entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _stop)
     )
-    
+
     return True
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if unload_ok:
+        hass.data[DOMAIN].pop("devices")
+        hass.data[DOMAIN].pop("scenes")
+        await hass.data[DOMAIN]["manager"][entry.entry_id].disconnect()
+        hass.data[DOMAIN].pop("manager")
+
+    return unload_ok

--- a/custom_components/plejd/pyplejd/__init__.py
+++ b/custom_components/plejd/pyplejd/__init__.py
@@ -57,7 +57,7 @@ class PlejdManager:
     async def _update_device(self, deviceState):
         address = deviceState["address"]
         if address in self.devices:
-            await self.devices[address].new_state(deviceState["state"], deviceState["dim"])
+            await self.devices[address].new_state(deviceState.get("state"), deviceState.get("dim", 0))
 
     @property
     def keepalive_interval(self):

--- a/custom_components/plejd/pyplejd/mesh.py
+++ b/custom_components/plejd/pyplejd/mesh.py
@@ -23,6 +23,10 @@ class PlejdMesh():
 
         self.pollonWrite = True
         self.statecallback = None
+        self.scenecallback = None
+        self.buttoncallback = None
+
+        self._ble_lock = asyncio.Lock()
 
     def add_mesh_node(self, device):
         if device not in self.mesh_nodes:
@@ -73,7 +77,6 @@ class PlejdMesh():
                 self._connected = True
                 self.client = client
                 _LOGGER.debug("Connected to Plejd mesh")
-                await asyncio.sleep(2)
                 if not await self._authenticate():
                     await self.client.disconnect()
                     self._connected = False
@@ -96,8 +99,14 @@ class PlejdMesh():
             _LOGGER.debug("Received LastData %s", data.hex())
             deviceState = decode_state(data)
             _LOGGER.debug("Decoded LastData %s", deviceState)
-            if self.statecallback and deviceState is not None:
+            if deviceState is None:
+                return
+            if self.statecallback and "state" in deviceState:
                 await self.statecallback(deviceState)
+            if self.scenecallback and "scene" in deviceState:
+                await self.scenecallback(deviceState)
+            if self.buttoncallback and "button" in deviceState:
+                await self.buttoncallback(deviceState)
 
         async def _lightlevel(_, lightlevel):
             _LOGGER.debug("Received LightLevel %s", lightlevel.hex())
@@ -121,9 +130,11 @@ class PlejdMesh():
 
     async def write(self, payload):
         try:
-            _LOGGER.debug("Writing data to Plejd mesh CT: %s", payload.hex())
-            data = encrypt_decrypt(self.crypto_key, self.connected_node, payload)
-            await self.client.write_gatt_char(PLEJD_DATA, data, response=True)
+            # TODO:
+            async with self._ble_lock:
+                _LOGGER.debug("Writing data to Plejd mesh CT: %s", payload.hex())
+                data = encrypt_decrypt(self.crypto_key, self.connected_node, payload)
+                await self.client.write_gatt_char(PLEJD_DATA, data, response=True)
         except (BleakError, asyncio.TimeoutError) as e:
             _LOGGER.warning("Plejd mesh write command failed: %s", str(e))
             return False
@@ -132,7 +143,8 @@ class PlejdMesh():
     async def set_state(self, address, state, dim=0):
         payload = encode_state(address, state, dim)
         retval = await self.write(payload)
-        await self.poll()
+        if self.pollonWrite:
+            await self.poll()
         return retval
 
     async def activate_scene(self, index):
@@ -143,6 +155,10 @@ class PlejdMesh():
         return retval
 
     async def ping(self):
+        async with self._ble_lock:
+            return await self._ping()
+                
+    async def _ping(self):
         if self.client is None:
             return False
         try:
@@ -162,55 +178,70 @@ class PlejdMesh():
         if self.client is None:
             return
         _LOGGER.debug("Polling Plejd mesh for current state")
-        await self.client.write_gatt_char(PLEJD_LIGHTLEVEL, b"\x01", response=True)
+        async with self._ble_lock:
+            await self.client.write_gatt_char(PLEJD_LIGHTLEVEL, b"\x01", response=True)
 
     async def _authenticate(self):
         if self.client is None:
             return False
         try:
-            _LOGGER.debug("Authenticating to plejd mesh")
-            await self.client.write_gatt_char(PLEJD_AUTH, b"\0x00", response=True)
-            challenge = await self.client.read_gatt_char(PLEJD_AUTH)
-            response = auth_response(self.crypto_key, challenge)
-            await self.client.write_gatt_char(PLEJD_AUTH, response, response=True)
-            if not await self.ping():
-                _LOGGER.debug("Authenticion failed")
-                return False
-            _LOGGER.debug("Authenticated successfully")
-            return True
+            async with self._ble_lock:
+                _LOGGER.debug("Authenticating to plejd mesh")
+                await self.client.write_gatt_char(PLEJD_AUTH, b"\0x00", response=True)
+                challenge = await self.client.read_gatt_char(PLEJD_AUTH)
+                response = auth_response(self.crypto_key, challenge)
+                await self.client.write_gatt_char(PLEJD_AUTH, response, response=True)
+                if not await self._ping():
+                    _LOGGER.debug("Authenticion failed")
+                    return False
+                _LOGGER.debug("Authenticated successfully")
+                return True
         except (BleakError, asyncio.TimeoutError) as e:
             _LOGGER.warning("Plejd authentication failed: %s", str(e))
-            return False
+        return False
 
 
 def decode_state(data):
     address = int(data[0])
+    cmdtype = data[1:3]
+    if not cmdtype == b"\x01\x10":
+        _LOGGER.debug("Got non-command data: %s", cmdtype)
+        return None
     cmd = data[3:5]
+
+    # if address == 0:
+    #     # Broadcast
+    #     pass
     if address == 1 and cmd == b"\x00\x1b":
         _LOGGER.debug("Got time data?")
         ts = struct.unpack_from("<I", data, 5)[0]
         dt = datetime.fromtimestamp(ts)
         _LOGGER.debug("Timestamp: %s (%s)", ts, dt)
         return None
+    # if address == 2:
+    #     # Scene update?
+    #     pass
 
-    dim, state = None, None
+    retval = {"address": address}
+
     if cmd == b"\x00\xc8" or cmd == b"\x00\x98":
-        state = bool(data[5])
-        dim = int.from_bytes(data[6:8], "little")
+        retval["state"] = bool(data[5])
+        retval["dim"] = int.from_bytes(data[6:8], "little")        
     elif cmd == b"\x00\x97":
-        state = bool(data[5])
+        retval["state"] = bool(data[5])
     elif cmd == b"\x00\x16":
-        _LOGGER.debug("A button was pressed")
-        return None
+        retval["address"] = int(data[5])
+        retval["button"] = int(data[6])
+        _LOGGER.info("Button pressed: %s", retval)
+    elif cmd == b"\x00\x21":
+        del retval["address"]
+        retval["scene"] = int(data[5])
+        _LOGGER.info("Scene triggered: %s", retval)
     else:
         _LOGGER.debug("Unknown command %s", cmd)
         return None
 
-    return {
-        "address": address,
-        "state": state,
-        "dim": dim,
-    }
+    return retval
 
 
 def encode_state(address, state, dim):


### PR DESCRIPTION
Enable unloading of the integration. You can now reload or remove the integration without restarting HA. 