### PR TITLE
dimCurve can be RelayNormal

### DIFF
--- a/custom_components/plejd/pyplejd/api.py
+++ b/custom_components/plejd/pyplejd/api.py
@@ -86,7 +86,7 @@ async def get_devices(**credentials):
 
         if settings is not None:
             if settings.get("dimCurve") is not None:
-                if settings.get("dimCurve") == "nonDimmable":
+                if settings.get("dimCurve") in ["nonDimmable", "RelayNormal"]:
                     dimmable = False
                 else:
                     dimmable = True


### PR DESCRIPTION
Fixes a new issue where non-dimmable loads (SPR-01, REL-02) are set to dimmable.