### PR TITLE
Shorter names

### DIFF
--- a/custom_components/plejd/light.py
+++ b/custom_components/plejd/light.py
@@ -46,7 +46,7 @@ class PlejdLight(LightEntity, CoordinatorEntity):
     def device_info(self):
         return {
             "identifiers": {(DOMAIN, f"{self.device.BLE_address}")},
-            "name": f"Plejd {self.device.model}",
+            "name": self.device.name,
             "manufacturer": "Plejd",
             "model": self.device.model,
             #"connections": ???,
@@ -54,10 +54,6 @@ class PlejdLight(LightEntity, CoordinatorEntity):
             "sw_version": f"{self.device.firmware} ({self.device.hardwareId})",
         }
     
-    @property
-    def name(self):
-        return self.device.name
-
     @property
     def unique_id(self):
         return f"{self.device.BLE_address}:{self.device.address}"

--- a/custom_components/plejd/switch.py
+++ b/custom_components/plejd/switch.py
@@ -44,7 +44,7 @@ class PlejdSwitch(SwitchEntity, CoordinatorEntity):
     def device_info(self):
         return {
             "identifiers": {(DOMAIN, f"{self.device.BLE_address}")},
-            "name": f"Plejd {self.device.model}",
+            "name": self.device.name,
             "manufacturer": "Plejd",
             "model": self.device.model,
             #"connections": ???,
@@ -56,10 +56,6 @@ class PlejdSwitch(SwitchEntity, CoordinatorEntity):
     def available(self):
         return self.device.available
     
-    @property
-    def name(self):
-        return self.device.name
-
     @property
     def unique_id(self):
         return f"{self.device.BLE_address}:{self.device.address}"


### PR DESCRIPTION
Remove the Plejd model from entity names.

(Fixes #16.)