### PR TITLE
Fix deprecated use of BLEdevice.rssi

### DIFF
--- a/custom_components/plejd/__init__.py
+++ b/custom_components/plejd/__init__.py
@@ -79,8 +79,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     # Search for devices in the mesh
     def _discovered_plejd(service_info: BluetoothServiceInfoBleak, *_):
         plejdManager.add_mesh_device(service_info.device, service_info.rssi)
-    bluetooth.async_register_callback(
-      config_entry.async_on_unload(
+    config_entry.async_on_unload(
         bluetooth.async_register_callback(
             hass,
             _discovered_plejd,

--- a/custom_components/plejd/pyplejd/__init__.py
+++ b/custom_components/plejd/pyplejd/__init__.py
@@ -19,14 +19,13 @@ class PlejdManager:
         self.mesh.statecallback = self._update_device
         self.devices = { }
         self.scenes = []
-        self.credentials = credentials
 
-    def add_mesh_device(self, device):
+    def add_mesh_device(self, device, rssi):
         _LOGGER.debug("Adding plejd %s", device)
         # for d in self.devices.values():
         #     addr = device.address.replace(":","").replace("-","").upper()
         #     if d.BLE_address.upper() == addr or addr in device.name:
-        return self.mesh.add_mesh_node(device)
+        return self.mesh.add_mesh_node(device, rssi)
         # _LOGGER.debug("Device was not expected in current mesh")
 
     async def close_stale(self, device):

--- a/custom_components/plejd/pyplejd/ble_device.py
+++ b/custom_components/plejd/pyplejd/ble_device.py
@@ -1,0 +1,16 @@
+"""
+Wrapper class for BLEDevice with RSSI from AdvertisementData.
+"""
+
+from bleak.backends.device import BLEDevice
+
+class BLEDeviceWithRssi:
+    def __init__(self, device: BLEDevice, rssi: int):
+        self.device = device
+        self.rssi = rssi
+
+    def __str__(self):
+        return self.device.__str__()
+
+    def __repr__(self):
+        return self.device.__repr__()

--- a/custom_components/plejd/pyplejd/ble_device.py
+++ b/custom_components/plejd/pyplejd/ble_device.py
@@ -14,3 +14,8 @@ class BLEDeviceWithRssi:
 
     def __repr__(self):
         return self.device.__repr__()
+
+    def __eq__(self, other):
+        if isinstance(other, BLEDeviceWithRssi):
+            return self.device == other.device
+        return False


### PR DESCRIPTION
This PR fixes the deprecation warning:
```
custom_components/plejd/pyplejd/mesh.py:71: FutureWarning: BLEDevice.rssi is deprecated and will be removed in a future version of Bleak, use AdvertisementData.rssi instead
  self.mesh_nodes.sort(key = lambda a: a.rssi, reverse = True)
```
BLEDevice.rssi has been deprecated since version 0.19.0.