### PR TITLE
Refactor PlejdClimate to use native value properties

### DIFF
--- a/custom_components/plejd/number.py
+++ b/custom_components/plejd/number.py
@@ -29,22 +29,21 @@ async def async_setup_entry(
 
 
 class PlejdClimate(PlejdDeviceBaseEntity, NumberEntity):
-
     _attr_unit_of_measurement = "%"
+    _attr_native_min_value = 0
+    _attr_native_max_value = 100
+    _attr_native_step = 1
 
     def __init__(self, device: dt.PlejdThermostat) -> None:
-        """Set up climate entity."""
-        NumberEntity.__init__(self)
-        PlejdDeviceBaseEntity.__init__(self, device)
-        self.device: dt.PlejdThermostat
-
-        self.min_value = self.device.limits.get("min", 0)
-        self.max_value = self.device.limits.get("max", 100)
-        self.step = self.device.limits.get("step", 5)
+        super().__init__(device)
+        self._attr_native_min_value = self.device.limits.get("min", 0)
+        self._attr_native_max_value = self.device.limits.get("max", 100)
+        self._attr_native_step = self.device.limits.get("step", 5)
 
     @property
-    def value(self) -> float | None:
+    def native_value(self) -> float | None:
         return self._data.get("target", None)
 
-    async def async_set_value(self, value: float):
+    async def async_set_native_value(self, value: float) -> None:
         await self.device.set_target_temp(value)
+


### PR DESCRIPTION
Refactor PlejdClimate class to use native properties for min, max, and step values.